### PR TITLE
上传文件的同时，为文件添加合适的ContentType属性值

### DIFF
--- a/AliyunOSS.php
+++ b/AliyunOSS.php
@@ -37,11 +37,15 @@ class AliyunOSS {
 
   public function uploadFile($key, $file)
   {
+    $finfo = finfo_open(FILEINFO_MIME);
+    $finfo_file = finfo_file($finfo, $file);
+    finfo_close($finfo);
     return $this->ossClient->putObject(array(
       'Bucket' => $this->bucket,
       'Key' => $key,
       'Content' => fopen($file, 'r'),
-      'ContentLength' => filesize($file)
+      'ContentLength' => filesize($file),
+      'ContentType' => strstr($finfo_file, ';', true),
     ));
   }
 


### PR DESCRIPTION
如果不设置此值，上传后的图片，在浏览器输入其地址，将会提示下载。